### PR TITLE
split out to separate visibility db

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -14,27 +14,9 @@ services:
         property: hostport
     - key: SERVICES
       value: history
-    - key: DBNAME
-      fromDatabase:
-        name: temporal
-        property: database
-    - key: VISIBILITY_DBNAME
-      fromDatabase:
-        name: temporal
-        property: database
-    - key: POSTGRES_USER
-      fromDatabase:
-        name: temporal
-        property: user
-    - key: POSTGRES_PWD
-      fromDatabase:
-        name: temporal
-        property: password
-    - key: POSTGRES_SEEDS
-      fromDatabase:
-        name: temporal
-        property: host
     - fromGroup: dynamic-config
+    - fromGroup: db-vars
+    - fromGroup: visibility-db-vars
   - type: pserv
     autoDeploy: false
     name: temporal-frontend
@@ -49,27 +31,9 @@ services:
         property: hostport
     - key: SERVICES
       value: frontend
-    - key: DBNAME
-      fromDatabase:
-        name: temporal
-        property: database
-    - key: VISIBILITY_DBNAME
-      fromDatabase:
-        name: temporal
-        property: database
-    - key: POSTGRES_USER
-      fromDatabase:
-        name: temporal
-        property: user
-    - key: POSTGRES_PWD
-      fromDatabase:
-        name: temporal
-        property: password
-    - key: POSTGRES_SEEDS
-      fromDatabase:
-        name: temporal
-        property: host
     - fromGroup: dynamic-config
+    - fromGroup: db-vars
+    - fromGroup: visibility-db-vars
   - type: pserv
     autoDeploy: false
     name: temporal-matching
@@ -84,27 +48,9 @@ services:
         property: hostport
     - key: SERVICES
       value: matching
-    - key: DBNAME
-      fromDatabase:
-        name: temporal
-        property: database
-    - key: VISIBILITY_DBNAME
-      fromDatabase:
-        name: temporal
-        property: database
-    - key: POSTGRES_USER
-      fromDatabase:
-        name: temporal
-        property: user
-    - key: POSTGRES_PWD
-      fromDatabase:
-        name: temporal
-        property: password
-    - key: POSTGRES_SEEDS
-      fromDatabase:
-        name: temporal
-        property: host
     - fromGroup: dynamic-config
+    - fromGroup: db-vars
+    - fromGroup: visibility-db-vars
   - type: pserv
     autoDeploy: false
     name: temporal-srv-worker
@@ -117,34 +63,16 @@ services:
         name: temporal-datadog-agent
         type: pserv
         property: hostport
-#     - key: PUBLIC_FRONTEND_ADDRESS
-#       fromService:
-#         name: temporal-frontend
-#         type: pserv
-#         property: hostport
+    - key: PUBLIC_FRONTEND_ADDRESS
+      fromService:
+        name: temporal-frontend
+        type: pserv
+        property: hostport
     - key: SERVICES
       value: worker
-    - key: DBNAME
-      fromDatabase:
-        name: temporal
-        property: database
-    - key: VISIBILITY_DBNAME
-      fromDatabase:
-        name: temporal
-        property: database
-    - key: POSTGRES_USER
-      fromDatabase:
-        name: temporal
-        property: user
-    - key: POSTGRES_PWD
-      fromDatabase:
-        name: temporal
-        property: password
-    - key: POSTGRES_SEEDS
-      fromDatabase:
-        name: temporal
-        property: host
     - fromGroup: dynamic-config
+    - fromGroup: db-vars
+    - fromGroup: visibility-db-vars
   - type: pserv
     autoDeploy: false
     name: temporal-datadog-agent
@@ -174,11 +102,20 @@ services:
     dockerfilePath: ./temporal/admin-tools/Dockerfile
     dockerContext: ./temporal/admin-tools
     envVars:
+    - fromGroup: dynamic-config
+    - fromGroup: db-vars
+    - fromGroup: visibility-db-vars
+
+envVarGroups:
+- name: dynamic-config
+  envVars:
+  - key: TEMPORAL_CONFIG_PATH
+    value: /etc/temporal/dynamicconfig.yaml
+  - key: DYNAMIC_CONFIG_FILE_PATH
+    value: /etc/temporal/dynamicconfig.yaml
+- name: db-vars
+  envVars:
     - key: DBNAME
-      fromDatabase:
-        name: temporal
-        property: database
-    - key: VISIBILITY_DBNAME
       fromDatabase:
         name: temporal
         property: database
@@ -198,18 +135,35 @@ services:
       fromDatabase:
         name: temporal
         property: host
-    - fromGroup: dynamic-config
-
-envVarGroups:
-- name: dynamic-config
+- name: visibility-db-vars
   envVars:
-  - key: TEMPORAL_CONFIG_PATH
-    value: /etc/temporal/dynamicconfig.yaml
-  - key: DYNAMIC_CONFIG_FILE_PATH
-    value: /etc/temporal/dynamicconfig.yaml
+    - key: VISIBILITY_DBNAME
+      fromDatabase:
+        name: temporal-visibility
+        property: database
+    - key: VISIBILITY_DB_PORT
+      fromDatabase:
+        name: temporal-visibility
+        property: port
+    - key: VISIBILITY_POSTGRES_USER
+      fromDatabase:
+        name: temporal-visibility
+        property: user
+    - key: VISIBILITY_POSTGRES_PWD
+      fromDatabase:
+        name: temporal-visibility
+        property: password
+    - key: VISIBILITY_POSTGRES_SEEDS
+      fromDatabase:
+        name: temporal-visibility
+        property: host
 
 databases:
   - name: temporal
     databaseName: temporal
     user: temporal
+    plan: standard
+  - name: temporal-visibility
+    databaseName: temporal-visibility
+    user: temporal-visibility
     plan: standard

--- a/temporal/admin-tools/setup-schema.sh
+++ b/temporal/admin-tools/setup-schema.sh
@@ -7,8 +7,8 @@ temporal-sql-tool --plugin postgres --endpoint "${POSTGRES_SEEDS}" --user "${POS
 temporal-sql-tool --plugin postgres --endpoint "${POSTGRES_SEEDS}" --user "${POSTGRES_USER}" --password "$POSTGRES_PWD" --port "${DB_PORT}" --db "${DBNAME}" update-schema -d "${SCHEMA_DIR}"
 VISIBILITY_SCHEMA_DIR=${TEMPORAL_HOME}/schema/postgresql/v96/visibility/versioned
 
-temporal-sql-tool --plugin postgres --endpoint "${POSTGRES_SEEDS}" --user "${POSTGRES_USER}" --password "$POSTGRES_PWD" --port "${DB_PORT}" --db "${VISIBILITY_DBNAME}" setup-schema -v 0.0
-temporal-sql-tool --plugin postgres --endpoint "${POSTGRES_SEEDS}" --user "${POSTGRES_USER}" --password "$POSTGRES_PWD" --port "${DB_PORT}" --db "${VISIBILITY_DBNAME}" update-schema -d "${VISIBILITY_SCHEMA_DIR}"
+temporal-sql-tool --plugin postgres --endpoint "${VISIBILITY_POSTGRES_SEEDS}" --user "${VISIBILITY_POSTGRES_USER}" --password "$VISIBILITY_POSTGRES_PWD" --port "${VISIBILITY_DB_PORT}" --db "${VISIBILITY_DBNAME}" setup-schema -v 0.0
+temporal-sql-tool --plugin postgres --endpoint "${VISIBILITY_POSTGRES_SEEDS}" --user "${VISIBILITY_POSTGRES_USER}" --password "$VISIBILITY_POSTGRES_PWD" --port "${VISIBILITY_DB_PORT}" --db "${VISIBILITY_DBNAME}" update-schema -d "${VISIBILITY_SCHEMA_DIR}"
 
 echo "Setting up namespaces... checking tctl"
 

--- a/temporal/server/Dockerfile
+++ b/temporal/server/Dockerfile
@@ -8,3 +8,4 @@ ENV SQL_TLS_ENABLED=true
 
 # uses Docker context $ROOT/temporal
 COPY config/dynamicconfig.yaml /etc/temporal/dynamicconfig.yaml
+COPY versioned-schema/ /etc/temporal/schema/postgresql/v96/temporal/versioned/

--- a/temporal/ui/Dockerfile
+++ b/temporal/ui/Dockerfile
@@ -4,3 +4,4 @@ ENV TEMPORAL_PERMIT_WRITE_API=true
 
 # uses Docker context $ROOT/temporal
 COPY config/dynamicconfig.yaml /etc/temporal/dynamicconfig.yaml
+COPY versioned-schema/ /etc/temporal/schema/postgresql/v96/temporal/versioned/

--- a/temporal/versioned-schema/database.sql
+++ b/temporal/versioned-schema/database.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE temporal;

--- a/temporal/versioned-schema/schema.sql
+++ b/temporal/versioned-schema/schema.sql
@@ -1,0 +1,295 @@
+CREATE TABLE namespaces(
+  partition_id INTEGER NOT NULL,
+  id BYTEA NOT NULL,
+  name VARCHAR(255) UNIQUE NOT NULL,
+  notification_version BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  is_global BOOLEAN NOT NULL,
+  PRIMARY KEY(partition_id, id)
+);
+
+CREATE TABLE namespace_metadata (
+  partition_id INTEGER NOT NULL,
+  notification_version BIGINT NOT NULL,
+  PRIMARY KEY(partition_id)
+);
+
+INSERT INTO namespace_metadata (partition_id, notification_version) VALUES (54321, 1);
+
+CREATE TABLE shards (
+  shard_id INTEGER NOT NULL,
+  --
+  range_id BIGINT NOT NULL,
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id)
+);
+
+CREATE TABLE executions(
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  --
+  next_event_id BIGINT NOT NULL,
+  last_write_version BIGINT NOT NULL,
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  state BYTEA NOT NULL,
+  state_encoding VARCHAR(16) NOT NULL,
+  db_record_version BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id)
+);
+
+CREATE TABLE current_executions(
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  --
+  run_id BYTEA NOT NULL,
+  create_request_id VARCHAR(64) NOT NULL,
+  state INTEGER NOT NULL,
+  status INTEGER NOT NULL,
+  start_version BIGINT NOT NULL DEFAULT 0,
+  last_write_version BIGINT NOT NULL,
+  PRIMARY KEY (shard_id, namespace_id, workflow_id)
+);
+
+CREATE TABLE buffered_events (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  id BIGSERIAL NOT NULL UNIQUE,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, id)
+);
+
+CREATE TABLE tasks (
+  range_hash BIGINT NOT NULL,
+  task_queue_id BYTEA NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id, task_id)
+);
+
+CREATE TABLE task_queues (
+  range_hash BIGINT NOT NULL,
+  task_queue_id BYTEA NOT NULL,
+  --
+  range_id BIGINT NOT NULL,
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id)
+);
+
+CREATE TABLE transfer_tasks(
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, task_id)
+);
+
+CREATE TABLE timer_tasks (
+  shard_id INTEGER NOT NULL,
+  visibility_timestamp TIMESTAMP NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, visibility_timestamp, task_id)
+);
+
+CREATE TABLE replication_tasks (
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, task_id)
+);
+
+CREATE TABLE replication_tasks_dlq (
+  source_cluster_name VARCHAR(255) NOT NULL,
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (source_cluster_name, shard_id, task_id)
+);
+
+CREATE TABLE visibility_tasks(
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, task_id)
+);
+
+CREATE TABLE tiered_storage_tasks(
+    shard_id      INTEGER     NOT NULL,
+    task_id       BIGINT      NOT NULL,
+    --
+    data          BYTEA       NOT NULL,
+    data_encoding VARCHAR(16) NOT NULL,
+    PRIMARY KEY (shard_id, task_id)
+);
+
+CREATE TABLE activity_info_maps (
+-- each row corresponds to one key of one map<string, ActivityInfo>
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  schedule_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, schedule_id)
+);
+
+CREATE TABLE timer_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  timer_id VARCHAR(255) NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, timer_id)
+);
+
+CREATE TABLE child_execution_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  initiated_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE request_cancel_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  initiated_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE signal_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  initiated_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE signals_requested_sets (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  signal_id VARCHAR(64) NOT NULL,
+  --
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, signal_id)
+);
+
+-- history eventsV2: history_node stores history event data
+CREATE TABLE history_node (
+  shard_id       INTEGER NOT NULL,
+  tree_id        BYTEA NOT NULL,
+  branch_id      BYTEA NOT NULL,
+  node_id        BIGINT NOT NULL,
+  txn_id         BIGINT NOT NULL,
+  --
+  prev_txn_id    BIGINT NOT NULL DEFAULT 0,
+  data           BYTEA NOT NULL,
+  data_encoding  VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, tree_id, branch_id, node_id, txn_id)
+);
+
+-- history eventsV2: history_tree stores branch metadata
+CREATE TABLE history_tree (
+  shard_id       INTEGER NOT NULL,
+  tree_id        BYTEA NOT NULL,
+  branch_id      BYTEA NOT NULL,
+  --
+  data           BYTEA NOT NULL,
+  data_encoding  VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, tree_id, branch_id)
+);
+
+CREATE TABLE queue (
+  queue_type        INTEGER NOT NULL,
+  message_id        BIGINT NOT NULL,
+  message_payload   BYTEA NOT NULL,
+  message_encoding  VARCHAR(16) NOT NULL,
+  PRIMARY KEY(queue_type, message_id)
+);
+
+CREATE TABLE queue_metadata (
+  queue_type     INTEGER NOT NULL,
+  data BYTEA     NOT NULL,
+  data_encoding  VARCHAR(16) NOT NULL,
+  version        BIGINT NOT NULL,
+  PRIMARY KEY(queue_type)
+);
+
+-- TODO deprecate this table in v1.15+
+CREATE TABLE cluster_metadata (
+  metadata_partition        INTEGER NOT NULL,
+  data                      BYTEA NOT NULL,
+  data_encoding             VARCHAR(16) NOT NULL,
+  version                   BIGINT NOT NULL,
+  PRIMARY KEY(metadata_partition)
+);
+
+CREATE TABLE cluster_metadata_info (
+  metadata_partition        INTEGER NOT NULL,
+  cluster_name              VARCHAR(255) NOT NULL,
+  data                      BYTEA NOT NULL,
+  data_encoding             VARCHAR(16) NOT NULL,
+  version                   BIGINT NOT NULL,
+  PRIMARY KEY(metadata_partition, cluster_name)
+);
+
+CREATE TABLE cluster_membership
+(
+    membership_partition INTEGER NOT NULL,
+    host_id              BYTEA NOT NULL,
+    rpc_address          VARCHAR(128) NOT NULL,
+    rpc_port             SMALLINT NOT NULL,
+    role                 SMALLINT NOT NULL,
+    session_start        TIMESTAMP DEFAULT '1970-01-01 00:00:01',
+    last_heartbeat       TIMESTAMP DEFAULT '1970-01-01 00:00:01',
+    record_expiry        TIMESTAMP DEFAULT '1970-01-01 00:00:01',
+    PRIMARY KEY (membership_partition, host_id)
+);
+
+CREATE UNIQUE INDEX cm_idx_rolehost ON cluster_membership (role, host_id);
+CREATE INDEX cm_idx_rolelasthb ON cluster_membership (role, last_heartbeat);
+CREATE INDEX cm_idx_rpchost ON cluster_membership (rpc_address, role);
+CREATE INDEX cm_idx_lasthb ON cluster_membership (last_heartbeat);
+CREATE INDEX cm_idx_recordexpiry ON cluster_membership (record_expiry);

--- a/temporal/versioned-schema/versioned/v1.0/manifest.json
+++ b/temporal/versioned-schema/versioned/v1.0/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.0",
+  "MinCompatibleVersion": "0.1",
+  "Description": "base version of schema",
+  "SchemaUpdateCqlFiles": [
+    "schema.sql"
+  ]
+}

--- a/temporal/versioned-schema/versioned/v1.0/schema.sql
+++ b/temporal/versioned-schema/versioned/v1.0/schema.sql
@@ -1,0 +1,261 @@
+CREATE TABLE namespaces(
+  partition_id INTEGER NOT NULL,
+  id BYTEA NOT NULL,
+  name VARCHAR(255) UNIQUE NOT NULL,
+  notification_version BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  is_global BOOLEAN NOT NULL,
+  PRIMARY KEY(partition_id, id)
+);
+
+CREATE TABLE namespace_metadata (
+  partition_id INTEGER NOT NULL,
+  notification_version BIGINT NOT NULL,
+  PRIMARY KEY(partition_id)
+);
+
+INSERT INTO namespace_metadata (partition_id, notification_version) VALUES (54321, 1);
+
+CREATE TABLE shards (
+  shard_id INTEGER NOT NULL,
+  --
+  range_id BIGINT NOT NULL,
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id)
+);
+
+CREATE TABLE transfer_tasks(
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, task_id)
+);
+
+CREATE TABLE executions(
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  --
+  next_event_id BIGINT NOT NULL,
+  last_write_version BIGINT NOT NULL,
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  state BYTEA NOT NULL,
+  state_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id)
+);
+
+CREATE TABLE current_executions(
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  --
+  run_id BYTEA NOT NULL,
+  create_request_id VARCHAR(64) NOT NULL,
+  state INTEGER NOT NULL,
+  status INTEGER NOT NULL,
+  start_version BIGINT NOT NULL,
+  last_write_version BIGINT NOT NULL,
+  PRIMARY KEY (shard_id, namespace_id, workflow_id)
+);
+
+CREATE TABLE buffered_events (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  id BIGSERIAL NOT NULL UNIQUE,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, id)
+);
+
+CREATE TABLE tasks (
+  range_hash BIGINT NOT NULL,
+  task_queue_id BYTEA NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id, task_id)
+);
+
+CREATE TABLE task_queues (
+  range_hash BIGINT NOT NULL,
+  task_queue_id BYTEA NOT NULL,
+  --
+  range_id BIGINT NOT NULL,
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id)
+);
+
+CREATE TABLE replication_tasks (
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, task_id)
+);
+
+CREATE TABLE replication_tasks_dlq (
+  source_cluster_name VARCHAR(255) NOT NULL,
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (source_cluster_name, shard_id, task_id)
+);
+
+CREATE TABLE timer_tasks (
+  shard_id INTEGER NOT NULL,
+  visibility_timestamp TIMESTAMP NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, visibility_timestamp, task_id)
+);
+
+CREATE TABLE activity_info_maps (
+-- each row corresponds to one key of one map<string, ActivityInfo>
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  schedule_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, schedule_id)
+);
+
+CREATE TABLE timer_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  timer_id VARCHAR(255) NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, timer_id)
+);
+
+CREATE TABLE child_execution_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  initiated_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE request_cancel_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  initiated_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE signal_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  initiated_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE signals_requested_sets (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  signal_id VARCHAR(64) NOT NULL,
+  --
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, signal_id)
+);
+
+-- history eventsV2: history_node stores history event data
+CREATE TABLE history_node (
+  shard_id       INTEGER NOT NULL,
+  tree_id        BYTEA NOT NULL,
+  branch_id      BYTEA NOT NULL,
+  node_id        BIGINT NOT NULL,
+  txn_id         BIGINT NOT NULL,
+  --
+  data           BYTEA NOT NULL,
+  data_encoding  VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, tree_id, branch_id, node_id, txn_id)
+);
+
+-- history eventsV2: history_tree stores branch metadata
+CREATE TABLE history_tree (
+  shard_id       INTEGER NOT NULL,
+  tree_id        BYTEA NOT NULL,
+  branch_id      BYTEA NOT NULL,
+  --
+  data           BYTEA NOT NULL,
+  data_encoding  VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, tree_id, branch_id)
+);
+
+CREATE TABLE queue (
+  queue_type INTEGER NOT NULL,
+  message_id BIGINT NOT NULL,
+  message_payload BYTEA NOT NULL,
+  PRIMARY KEY(queue_type, message_id)
+);
+
+CREATE TABLE queue_metadata (
+  queue_type INTEGER NOT NULL,
+  data BYTEA NOT NULL,
+  PRIMARY KEY(queue_type)
+);
+
+CREATE TABLE cluster_metadata (
+  metadata_partition        INTEGER NOT NULL,
+  immutable_data            BYTEA NOT NULL,
+  immutable_data_encoding   VARCHAR(16) NOT NULL,
+  PRIMARY KEY(metadata_partition)
+);
+
+CREATE TABLE cluster_membership
+(
+    membership_partition INTEGER NOT NULL,
+    host_id              BYTEA NOT NULL,
+    rpc_address          VARCHAR(15) NOT NULL,
+    rpc_port             SMALLINT NOT NULL,
+    role                 SMALLINT NOT NULL,
+    session_start        TIMESTAMP DEFAULT '1970-01-01 00:00:01',
+    last_heartbeat       TIMESTAMP DEFAULT '1970-01-01 00:00:01',
+    record_expiry        TIMESTAMP DEFAULT '1970-01-01 00:00:01',
+    PRIMARY KEY (membership_partition, host_id)
+);
+
+CREATE UNIQUE INDEX cm_idx_rolehost ON cluster_membership (role, host_id);
+CREATE INDEX cm_idx_rolelasthb ON cluster_membership (role, last_heartbeat);
+CREATE INDEX cm_idx_rpchost ON cluster_membership (rpc_address, role);
+CREATE INDEX cm_idx_lasthb ON cluster_membership (last_heartbeat);
+CREATE INDEX cm_idx_recordexpiry ON cluster_membership (record_expiry);

--- a/temporal/versioned-schema/versioned/v1.1/cluster_metadata.sql
+++ b/temporal/versioned-schema/versioned/v1.1/cluster_metadata.sql
@@ -1,0 +1,3 @@
+ALTER TABLE cluster_metadata ADD data BYTEA NOT NULL DEFAULT '';
+ALTER TABLE cluster_metadata ADD data_encoding VARCHAR(16) NOT NULL DEFAULT 'Proto3';
+ALTER TABLE cluster_metadata ADD version BIGINT NOT NULL DEFAULT 1;

--- a/temporal/versioned-schema/versioned/v1.1/manifest.json
+++ b/temporal/versioned-schema/versioned/v1.1/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.1",
+  "MinCompatibleVersion": "1.0",
+  "Description": "schema update for cluster metadata",
+  "SchemaUpdateCqlFiles": [
+    "cluster_metadata.sql"
+  ]
+}

--- a/temporal/versioned-schema/versioned/v1.2/manifest.json
+++ b/temporal/versioned-schema/versioned/v1.2/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.2",
+  "MinCompatibleVersion": "1.0",
+  "Description": "schema update for RPC replication",
+  "SchemaUpdateCqlFiles": [
+    "queue.sql"
+  ]
+}

--- a/temporal/versioned-schema/versioned/v1.2/queue.sql
+++ b/temporal/versioned-schema/versioned/v1.2/queue.sql
@@ -1,0 +1,2 @@
+ALTER TABLE queue ADD message_encoding VARCHAR(16) NOT NULL DEFAULT 'Json';
+ALTER TABLE queue_metadata ADD data_encoding VARCHAR(16) NOT NULL DEFAULT 'Json';

--- a/temporal/versioned-schema/versioned/v1.3/manifest.json
+++ b/temporal/versioned-schema/versioned/v1.3/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.3",
+  "MinCompatibleVersion": "1.0",
+  "Description": "schema update for kafka deprecation",
+  "SchemaUpdateCqlFiles": [
+    "visibility_tasks.sql"
+  ]
+}

--- a/temporal/versioned-schema/versioned/v1.3/visibility_tasks.sql
+++ b/temporal/versioned-schema/versioned/v1.3/visibility_tasks.sql
@@ -1,0 +1,8 @@
+CREATE TABLE visibility_tasks(
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, task_id)
+);

--- a/temporal/versioned-schema/versioned/v1.4/cluster_metadata.sql
+++ b/temporal/versioned-schema/versioned/v1.4/cluster_metadata.sql
@@ -1,0 +1,2 @@
+ALTER TABLE cluster_metadata DROP immutable_data;
+ALTER TABLE cluster_metadata DROP immutable_data_encoding;

--- a/temporal/versioned-schema/versioned/v1.4/manifest.json
+++ b/temporal/versioned-schema/versioned/v1.4/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.4",
+  "MinCompatibleVersion": "1.0",
+  "Description": "schema update for cluster metadata cleanup",
+  "SchemaUpdateCqlFiles": [
+    "cluster_metadata.sql"
+  ]
+}

--- a/temporal/versioned-schema/versioned/v1.5/cluster_membership.sql
+++ b/temporal/versioned-schema/versioned/v1.5/cluster_membership.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cluster_membership ALTER COLUMN rpc_address TYPE VARCHAR(128);

--- a/temporal/versioned-schema/versioned/v1.5/event.sql
+++ b/temporal/versioned-schema/versioned/v1.5/event.sql
@@ -1,0 +1,1 @@
+ALTER TABLE history_node ADD prev_txn_id BIGINT NOT NULL DEFAULT 0;

--- a/temporal/versioned-schema/versioned/v1.5/executions.sql
+++ b/temporal/versioned-schema/versioned/v1.5/executions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE executions ADD db_record_version BIGINT NOT NULL DEFAULT 0;

--- a/temporal/versioned-schema/versioned/v1.5/manifest.json
+++ b/temporal/versioned-schema/versioned/v1.5/manifest.json
@@ -1,0 +1,10 @@
+{
+  "CurrVersion": "1.5",
+  "MinCompatibleVersion": "1.0",
+  "Description": "schema update for cluster_membership, executions and history_node tables",
+  "SchemaUpdateCqlFiles": [
+    "event.sql",
+    "executions.sql",
+    "cluster_membership.sql"
+  ]
+}

--- a/temporal/versioned-schema/versioned/v1.6/manifest.json
+++ b/temporal/versioned-schema/versioned/v1.6/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.6",
+  "MinCompatibleVersion": "1.0",
+  "Description": "schema update for queue_metadata",
+  "SchemaUpdateCqlFiles": [
+    "queue_metadata.sql"
+  ]
+}

--- a/temporal/versioned-schema/versioned/v1.6/queue_metadata.sql
+++ b/temporal/versioned-schema/versioned/v1.6/queue_metadata.sql
@@ -1,0 +1,1 @@
+ALTER TABLE queue_metadata ADD version BIGINT NOT NULL DEFAULT 0;

--- a/temporal/versioned-schema/versioned/v1.7/cluster_metadata_info.sql
+++ b/temporal/versioned-schema/versioned/v1.7/cluster_metadata_info.sql
@@ -1,0 +1,8 @@
+CREATE TABLE cluster_metadata_info (
+  metadata_partition        INTEGER NOT NULL,
+  cluster_name              VARCHAR(255) NOT NULL,
+  data                      BYTEA NOT NULL,
+  data_encoding             VARCHAR(16) NOT NULL,
+  version                   BIGINT NOT NULL,
+  PRIMARY KEY(metadata_partition, cluster_name)
+);

--- a/temporal/versioned-schema/versioned/v1.7/manifest.json
+++ b/temporal/versioned-schema/versioned/v1.7/manifest.json
@@ -1,0 +1,10 @@
+{
+  "CurrVersion": "1.7",
+  "MinCompatibleVersion": "1.0",
+  "Description": "create cluster metadata info table to store cluster information and executions to store tiered storage queue",
+  "SchemaUpdateCqlFiles": [
+    "cluster_metadata_info.sql",
+    "no_start_version.sql",
+    "tiered_storage_tasks.sql"
+  ]
+}

--- a/temporal/versioned-schema/versioned/v1.7/no_start_version.sql
+++ b/temporal/versioned-schema/versioned/v1.7/no_start_version.sql
@@ -1,0 +1,1 @@
+ALTER TABLE current_executions ALTER COLUMN start_version SET DEFAULT 0;

--- a/temporal/versioned-schema/versioned/v1.7/tiered_storage_tasks.sql
+++ b/temporal/versioned-schema/versioned/v1.7/tiered_storage_tasks.sql
@@ -1,0 +1,8 @@
+CREATE TABLE tiered_storage_tasks(
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, task_id)
+);


### PR DESCRIPTION
a limitation in Render forces us to use a second db just to store visibility

our db guy Yimin says this is ok

i also added COPY for versioned-schema in hopes that this will help with schema-setup